### PR TITLE
feat: ignore deals started more than 60 days ago

### DIFF
--- a/scripts/build-spark-update-sql.js
+++ b/scripts/build-spark-update-sql.js
@@ -47,7 +47,7 @@ await pipeline(
       counter++
 
       if (counter % 5000 === 1) {
-        if (counter > 1) yield END_OF_INSERT_STATEMENT;
+        if (counter > 1) yield END_OF_INSERT_STATEMENT
         yield 'INSERT INTO retrievable_deals (cid, miner_id, client_id, expires_at) VALUES\n'
       } else {
         yield ',\n'

--- a/scripts/build-spark-update-sql.js
+++ b/scripts/build-spark-update-sql.js
@@ -42,7 +42,7 @@ await pipeline(
       // Skip deals that were created more than 60 days ago. These deals should be already in our DB.
       // IMPORTANT: after changing the logic determining which deals are eligible for testing,
       // disable this condition for the first run to ingest *all* deals again.
-      if (deal.started < Date.now() - 60 * ONE_DAY_IN_MS) return
+      if (deal.started < Date.now() - 60 * ONE_DAY_IN_MS) continue
 
       counter++
 

--- a/scripts/build-spark-update-sql.js
+++ b/scripts/build-spark-update-sql.js
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url'
 import split2 from 'split2'
 import pg from 'pg'
 
+const ONE_DAY_IN_MS = 24 * 60 * 60_000
+
 const thisDir = dirname(fileURLToPath(import.meta.url))
 const infile = resolve(thisDir, '../generated/retrievable-deals.ndjson')
 const outfile = resolve(thisDir, '../generated/update-spark-db.sql')
@@ -28,12 +30,21 @@ await pipeline(
     yield 'DELETE FROM retrievable_deals WHERE expires_at < now();\n'
 
     let counter = 0
-    for await (const task of source) {
-      assert(task.payloadCID)
-      assert(task.expires)
+    for await (const deal of source) {
+      signal.throwIfAborted()
+
+      assert(deal.payloadCID)
+      assert(deal.provider)
+      assert(deal.client)
+      assert(deal.started)
+      assert(deal.expires)
+
+      // Skip deals that were created more than 60 days ago. These deals should be already in our DB.
+      // IMPORTANT: after changing the logic determining which deals are eligible for testing,
+      // disable this condition for the first run to ingest *all* deals again.
+      if (deal.started < Date.now() - 60 * ONE_DAY_IN_MS) return
 
       counter++
-      signal.throwIfAborted()
 
       if (counter % 5000 === 1) {
         if (counter > 1) yield END_OF_INSERT_STATEMENT;
@@ -43,7 +54,7 @@ await pipeline(
       }
 
       const q = `(${[
-        task.payloadCID, task.provider, task.client, new Date(task.expires).toISOString()
+        deal.payloadCID, deal.provider, deal.client, new Date(deal.expires).toISOString()
       ].map(pg.escapeLiteral).join(', ')})`
       yield q
       // console.log(q)

--- a/scripts/parse-retrievable-deals.js
+++ b/scripts/parse-retrievable-deals.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert'
 import { createReadStream, createWriteStream } from 'node:fs'
-import { readFile } from 'node:fs/promises'
 import { dirname, resolve, relative } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
@@ -107,9 +106,9 @@ function * processDeal (deal) {
   assert.strictEqual(typeof EndEpoch, 'number', `EndEpoch is not a number: ${JSON.stringify(deal.Proposal)}`)
   const expires = EndEpoch * BLOCK_TIME + GENESIS_TS
 
-   // Skip deals that expire in 24 hours
-   const tomorrow = Date.now() + 24 /* hours/day */ * 3600_000
-   if (expires < tomorrow) return
+  // Skip deals that have expired or expire in less than 24 hours
+  const tomorrow = Date.now() + 24 /* hours/day */ * 3600_000
+  if (expires < tomorrow) return
 
   // Skip deals that don't have payload CID metadata
   // TODO: handle other CID formats
@@ -124,8 +123,7 @@ function * processDeal (deal) {
     pieceCID: PieceCID['/'],
     payloadCID: Label,
     started,
-    expires,
+    expires
   }
   yield entry
 }
-

--- a/scripts/parse-retrievable-deals.js
+++ b/scripts/parse-retrievable-deals.js
@@ -99,10 +99,9 @@ function * processDeal (deal) {
   // FIXME: investigate why some deals don't have any PieceCID
   if (!PieceCID) return
 
-  // Skip deals that were created before June 2023 (this date is somewhat arbitrary :shrug:)
+  // Calculate when the deal started
   assert.strictEqual(typeof StartEpoch, 'number', `StartEpoch is not a number: ${JSON.stringify(deal.Proposal)}`)
   const started = StartEpoch * BLOCK_TIME + GENESIS_TS
-  if (started < new Date('2023-06-01T00:00:00.000Z')) return
 
   // Calculate when the deal expires
   assert.strictEqual(typeof EndEpoch, 'number', `EndEpoch is not a number: ${JSON.stringify(deal.Proposal)}`)
@@ -124,6 +123,7 @@ function * processDeal (deal) {
     client: Client,
     pieceCID: PieceCID['/'],
     payloadCID: Label,
+    started,
     expires,
   }
   yield entry

--- a/scripts/update-allocator-clients.js
+++ b/scripts/update-allocator-clients.js
@@ -1,6 +1,5 @@
 import 'dotenv/config'
 
-import assert from 'node:assert'
 import fs from 'node:fs/promises'
 import { setTimeout } from 'node:timers/promises'
 import pg from 'pg'
@@ -48,7 +47,7 @@ for (const { client_id: clientId } of clientsMissingAllocator) {
   console.log('Fetching allowance info for the client %s', clientId)
 
   const res = await fetch(
-    buildUrlWithQueryString(`getVerifiedClients`, { filter: clientId, limit: 1000 }),
+    buildUrlWithQueryString('getVerifiedClients', { filter: clientId, limit: 1000 }),
     { headers: { 'X-API-KEY': DATACAPS_TOKEN } }
   )
   if (!res.ok) {


### PR DESCRIPTION
Deals created more than 60 days ago should be already in our DB, ingested by
one of the previous runs of the ingester script.

- **perf:: ignore deals started more than 60 days ago**
- **chore: standard --fix**
