### PR TITLE
Improve fil-deal-ingester error handling

### DIFF
--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -16,7 +16,6 @@ jobs:
           - split2
           - varint
           - env_logger
-          - json-event-parser
           - log
           - zstd
           - anyhow

--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -16,9 +16,9 @@ jobs:
           - split2
           - varint
           - env_logger
-          - json-event-parser
           - log
           - zstd
+          - anyhow
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -16,6 +16,7 @@ jobs:
           - split2
           - varint
           - env_logger
+          - json-event-parser
           - log
           - zstd
           - anyhow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,7 @@ dependencies = [
 name = "fil-deal-ingester"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "env_logger",
  "json-event-parser",
  "log",
@@ -133,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "json-event-parser"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850fafca79ebacd70eab9d80cb75a33aeda38bde8f3dd784c1837cdf0bde631"
+checksum = "32f12e624eaeb74accb9bb48f01cb071427f68115aaafa5689acb372d7e22977"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "json-event-parser"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850fafca79ebacd70eab9d80cb75a33aeda38bde8f3dd784c1837cdf0bde631"
+checksum = "32f12e624eaeb74accb9bb48f01cb071427f68115aaafa5689acb372d7e22977"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "json-event-parser"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f12e624eaeb74accb9bb48f01cb071427f68115aaafa5689acb372d7e22977"
+checksum = "f850fafca79ebacd70eab9d80cb75a33aeda38bde8f3dd784c1837cdf0bde631"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.95"
 env_logger = "0.11.2"
-json-event-parser = "0.2.0"
+json-event-parser = "0.1.1"
 log = "0.4.25"
 zstd = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.95"
 env_logger = "0.11.2"
-json-event-parser = "0.1.1"
+json-event-parser = "0.2.0"
 log = "0.4.25"
 zstd = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.95"
 env_logger = "0.11.2"
-json-event-parser = "0.2.0"
+json-event-parser = "0.1.1"
 log = "0.4.25"
 zstd = "0.13.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,65 +1,67 @@
+use anyhow::{bail, ensure, Context, Result};
 use json_event_parser::{JsonEvent, JsonReader, JsonWriter};
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::init();
 
-    let infile = match env::args().skip(1).next() {
-        Some(f) => f,
-        None => panic!("Missing required argument: path to StorageMarketDeals.json.zst"),
-    };
+    let infile = env::args()
+        .nth(1)
+        .context("Missing required argument: path to StorageMarketDeals.json.zst")?;
 
-    assert!(
+    ensure!(
         infile.ends_with(".json.zst"),
         "The StorageMarketDeals file must have .json.zst extension"
     );
-    let f = File::open(infile).expect("cannot open input file");
+
+    let f = File::open(&infile).context("cannot open input file")?;
     let decoder =
-        zstd::stream::Decoder::new(BufReader::new(f)).expect("cannot create zstd decoder");
+        zstd::stream::Decoder::new(BufReader::new(f)).context("cannot create zstd decoder")?;
     let mut reader = JsonReader::from_reader(BufReader::new(decoder));
 
     let mut buffer = Vec::new();
 
-    assert_eq!(
-        reader.read_event(&mut buffer).expect("cannot parse JSON"),
-        JsonEvent::StartObject,
-    );
+    let start_event = reader
+        .read_event(&mut buffer)
+        .context("cannot parse JSON")?;
+
+    ensure!(start_event == JsonEvent::StartObject);
 
     loop {
-        let event = reader.read_event(&mut buffer).expect("cannot parse JSON");
+        let event = reader.read_event(&mut buffer)?;
         log::debug!("{:?}", event);
 
         match event {
-            JsonEvent::ObjectKey(_) => parse_deal(&mut reader, &mut buffer),
-            JsonEvent::EndObject => {
-                let event = reader.read_event(&mut buffer).expect("cannot parse JSON");
-                if event == JsonEvent::Eof {
-                    break;
-                } else {
-                    panic!("unexpected JSON event after EndObject: {event:?}")
+            JsonEvent::ObjectKey(_) => parse_deal(&mut reader, &mut buffer)?,
+            JsonEvent::EndObject => match reader.read_event(&mut buffer)? {
+                JsonEvent::Eof => break,
+                event => {
+                    bail!("unexpected JSON event after EndObject: {:?}", event);
                 }
-            }
-            _ => panic!("unexpected JSON event: {event:?}"),
-        };
+            },
+            _ => bail!("unexpected JSON event: {:?}", event),
+        }
     }
+
+    Ok(())
 }
 
-fn parse_deal<R: BufRead>(reader: &mut JsonReader<R>, buffer: &mut Vec<u8>) {
+fn parse_deal<R: BufRead>(reader: &mut JsonReader<R>, buffer: &mut Vec<u8>) -> Result<()> {
     let mut output = Vec::new();
     let mut writer = JsonWriter::from_writer(&mut output);
 
     let mut depth = 0;
 
     loop {
-        let event = reader.read_event(buffer).expect("cannot parse JSON");
+        let event = reader.read_event(buffer).context("cannot parse JSON")?;
         if depth == 0 {
-            assert_eq!(event, JsonEvent::StartObject,);
+            ensure!(event == JsonEvent::StartObject);
             log::debug!("==DEAL START==");
         }
 
-        writer.write_event(event).expect("cannot write JSON");
+        writer.write_event(event).context("cannot write JSON")?;
 
         match event {
             JsonEvent::StartObject => {
@@ -81,5 +83,5 @@ fn parse_deal<R: BufRead>(reader: &mut JsonReader<R>, buffer: &mut Vec<u8>) {
     output.push(b'\n');
     let _ = std::io::stdout().write(&output);
     let _ = std::io::stdout().flush();
-    // println!("{}", std::str::from_utf8(&output).expect("malformed UTF-8"));
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, ensure, Context, Result};
-use json_event_parser::{JsonEvent, JsonReader, JsonWriter};
+use json_event_parser::{FromReadJsonReader, JsonEvent, ToWriteJsonWriter};
 use std::env;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -19,23 +19,19 @@ fn main() -> Result<()> {
     let f = File::open(&infile).context("cannot open input file")?;
     let decoder =
         zstd::stream::Decoder::new(BufReader::new(f)).context("cannot create zstd decoder")?;
-    let mut reader = JsonReader::from_reader(BufReader::new(decoder));
+    let mut reader = FromReadJsonReader::new(BufReader::new(decoder));
 
-    let mut buffer = Vec::new();
-
-    let start_event = reader
-        .read_event(&mut buffer)
-        .context("cannot parse JSON")?;
+    let start_event = reader.read_next_event().context("cannot parse JSON")?;
 
     ensure!(start_event == JsonEvent::StartObject);
 
     loop {
-        let event = reader.read_event(&mut buffer)?;
+        let event = reader.read_next_event()?;
         log::debug!("{:?}", event);
 
         match event {
-            JsonEvent::ObjectKey(_) => parse_deal(&mut reader, &mut buffer)?,
-            JsonEvent::EndObject => match reader.read_event(&mut buffer)? {
+            JsonEvent::ObjectKey(_) => parse_deal(&mut reader)?,
+            JsonEvent::EndObject => match reader.read_next_event()? {
                 JsonEvent::Eof => break,
                 event => {
                     bail!("unexpected JSON event after EndObject: {:?}", event);
@@ -48,20 +44,20 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn parse_deal<R: BufRead>(reader: &mut JsonReader<R>, buffer: &mut Vec<u8>) -> Result<()> {
+fn parse_deal<R: BufRead>(reader: &mut FromReadJsonReader<R>) -> Result<()> {
     let mut output = Vec::new();
-    let mut writer = JsonWriter::from_writer(&mut output);
+    let mut writer = ToWriteJsonWriter::new(&mut output);
 
     let mut depth = 0;
 
     loop {
-        let event = reader.read_event(buffer).context("cannot parse JSON")?;
+        let event = reader.read_next_event().context("cannot parse JSON")?;
         if depth == 0 {
             ensure!(event == JsonEvent::StartObject);
             log::debug!("==DEAL START==");
         }
 
-        writer.write_event(event).context("cannot write JSON")?;
+        writer.write_event(event.clone()).context("cannot write JSON")?;
 
         match event {
             JsonEvent::StartObject => {


### PR DESCRIPTION
This PR adds `anyhow` create to handle errors propagation and asserts

Related to #31
Loosely related to #23 